### PR TITLE
Initial powerpc64/powerpc64le support.

### DIFF
--- a/src/engine/engine/common/build.c
+++ b/src/engine/engine/common/build.c
@@ -140,6 +140,10 @@ const char *Q_buildarch( void )
 	archname = "mips";
 #elif XASH_MIPS && XASH_LITTLE_ENDIAN
 	archname = "mipsel";
+#elif XASH_PPC64 && XASH_BIG_ENDIAN
+	archname = "powerpc64";
+#elif XASH_PPC64 && XASH_LITTLE_ENDIAN
+	archname = "powerpc64le";
 #elif XASH_JS
 	archname = "javascript";
 #elif XASH_E2K

--- a/src/engine/public/build.h
+++ b/src/engine/public/build.h
@@ -198,6 +198,8 @@ For more information, please refer to <http://unlicense.org/>
 	#endif // __SOFTFP__
 #elif defined __mips__
 	#define XASH_MIPS 1
+#elif defined __powerpc64__
+	#define XASH_PPC64 1
 #elif defined __EMSCRIPTEN__
 	#define XASH_JS 1
 #elif defined __e2k__


### PR DESCRIPTION
This change is to enable building on powerpc64/powerpc64le.

Have tested on powerpc64le, works OK.

Have not been able to test on powerpc64 yet due to an issue with mono on that platform (https://github.com/mono/mono/issues/19399) though will test once this is resolved.